### PR TITLE
Fix blocking in network-less environment

### DIFF
--- a/netron_export/_netron_export_graph.py
+++ b/netron_export/_netron_export_graph.py
@@ -41,6 +41,14 @@ async def save_model_graphs(netron_url: str, out_paths: List[str], horizontal_mo
                 print("Installation of playwright dependencies finished")
 
             page = await browser.new_page()
+            async def handle(route, request):
+                # Block url's other than netron_url
+                if not request.url.startswith(netron_url):
+                    await route.abort()
+                else:
+                    await route.continue_()
+
+            await page.route("**/*", handle)
             await page.goto(netron_url)
 
             # Click on the main button Accept of the first screen


### PR DESCRIPTION
Hey @raphael-prevost , Thanks for your work, and this is a pretty nice project. 

I got a timeout when I use this tool in a network-less environment (for example, offline machine). And the browser shows a loading screen.

![image](https://github.com/raphael-prevost/netron-export/assets/14936301/d1f5c210-bdc5-4de4-bdcf-ae8946bebd4a)

By capturing the network activity, I realized that it is trying to fetch https://ipinfo.io/json (see the code [here](https://github.com/lutzroeder/netron/blob/925784cb577a495057b59c138885401909ea6f70/source/browser.js#L74))

Actuary, These are the url's which netron visited:

```txt
request.url: http://127.0.0.1:8487/
request.url: http://127.0.0.1:8487/grapher.css
request.url: http://127.0.0.1:8487/index.js
request.url: http://127.0.0.1:8487/base.js
request.url: http://127.0.0.1:8487/text.js
request.url: http://127.0.0.1:8487/flatbuffers.js
request.url: http://127.0.0.1:8487/flexbuffers.js
request.url: http://127.0.0.1:8487/zip.js
request.url: http://127.0.0.1:8487/tar.js
request.url: http://127.0.0.1:8487/python.js
request.url: http://127.0.0.1:8487/dagre.js
request.url: http://127.0.0.1:8487/json.js
request.url: http://127.0.0.1:8487/xml.js
request.url: http://127.0.0.1:8487/protobuf.js
request.url: http://127.0.0.1:8487/hdf5.js
request.url: http://127.0.0.1:8487/grapher.js
request.url: http://127.0.0.1:8487/browser.js
request.url: http://127.0.0.1:8487/view.js
request.url: https://ipinfo.io/json
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=1&sid=1700907513050&sct=1&seg=0&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=2&sid=1700907513050&sct=1&seg=0&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: https://www.google-analytics.com/analytics.js
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=3&sid=1700907513050&sct=1&seg=0&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=4&sid=1700907513050&sct=1&seg=0&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=5&sid=1700907513050&sct=1&seg=0&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: http://127.0.0.1:8487/data/subgraph_sw_2.ms?cb=1700907513079
request.url: http://127.0.0.1:8487/mslite.js
request.url: http://127.0.0.1:8487/mslite-schema.js
request.url: http://127.0.0.1:8487/mslite-metadata.json
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=6&sid=1700907513050&sct=1&seg=1&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=7&sid=1700907513050&sct=1&seg=1&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
request.url: https://analytics.google.com/g/collect?v=2&tid=G-848W2NVWVH&gtm=2oebu0&_p=1219407540&cid=1162333490.1700907513&ul=en-us&sr=1280x720&uaa=x86&uab=64&uafvl=Not_A%2520Brand%3B8.0.0.0%7CChromium%3B120.0.6099.28%7CHeadlessChrome%3B120.0.6099.28&uamb=0&uam=&uap=Linux&uapv=5.8.0&uaw=0&_s=8&sid=1700907513050&sct=1&seg=1&dl=http%3A%2F%2F127.0.0.1%3A8487%2F&dt=Netron
```

This PR is aim at blocking url's other than netron_url, to use this tool in a network-less environment and avoid tracking.
