### PR TITLE
Bump playwright version to 1.39 for python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 
 import setuptools
 
@@ -33,7 +34,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "netron @ git+https://github.com/raphael-prevost/netron.git@v7.6.5#subdirectory=dist/pypi",
-        "playwright==1.37.0"
+        # for python 3.12, we need greenlet>=3.0, which comes first with playwright>=1.39
+        "playwright==1.37.0" if sys.version_info[1] < 12 else "playwright==1.39.0"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Bumping playwright version to 1.39 conditional on python version being 3.12. This is needed to get `greenlet>=3.0` as dependency, which is the first version compatible with python 3.12